### PR TITLE
Update Hugo to version 0.36.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Runs Hugo static site generator as a compiler
 #
-FROM devopsdays/docker-hugo:v0.30.2
+FROM devopsdays/docker-hugo:v0.36.1
 MAINTAINER Matt Stratton <matt.stratton@gmail.com>
 
 WORKDIR /site

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ https://hub.docker.com/r/devopsdays/docker-hugo-compiler/ . Docker Hub will
 automatically update the creation of the Docker image when it detects any
 changes made to this repository.
 
-**devopsdays/docker-hugo-compiler** is an installation of Hugo release 0.30.2
+**devopsdays/docker-hugo-compiler** is an installation of Hugo release 0.36.1
 running on Alpine Linux release 3.4.
 
 

--- a/build
+++ b/build
@@ -11,4 +11,4 @@
 # License: MIT
 #
 
-docker build -t devopsdays/hugo-compiler:0.30.2 .
+docker build -t devopsdays/docker-hugo-compiler:0.36.1 .

--- a/hugoCompiler
+++ b/hugoCompiler
@@ -5,4 +5,4 @@
 # Purpose: Run the Hugo container as a compiler
 #
 
-docker run -v $(pwd):/site -e SITE_URL="${1}" devopsdays/docker-hugo-compiler:0.30.2
+docker run -v $(pwd):/site -e SITE_URL="${1}" devopsdays/docker-hugo-compiler:0.36.1


### PR DESCRIPTION
Updated to utilise the new docker-hugo version v0.36.1 base